### PR TITLE
Major Version Warning Added

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -4,6 +4,7 @@ use crate::types::flag::Flag;
 use crate::types::status::Status;
 use crate::types::version_number::VersionNumber;
 use crate::utils;
+use crate::utils::version_control::get_latest_version;
 
 /// The definition of the update command.
 pub(crate) fn definition() -> Command {
@@ -27,6 +28,8 @@ pub(crate) fn update(command: &Command) -> Status {
     if !utils::functions::check_internet_connection() {
         return Status::error("You need a internet connection to update templify.".to_string());
     }
+    let mut current_version = VersionNumber::new();
+    current_version.parse_from_string(env!("CARGO_PKG_VERSION"));
 
     let version = command.get_value_flag("version").clone();
 
@@ -44,8 +47,27 @@ pub(crate) fn update(command: &Command) -> Status {
             return Status::error("Versions older than 1.0.0 are not supported.".to_string());
         }
 
+        if current_version.is_major_update(&version_number) {
+            log!(" ");
+            log!("Warning, Updating Major Version can have breaking changes. Please consider reading documentation after update.");
+            log!(" ");
+            log!("To get more information please visit: https://github.com/cophilot/templify/blob/master/CHANGELOG.md");
+            log!(" ");
+        }
+
         log!("Updating templify to version {}...", version);
     } else {
+        let mut latest_verion = VersionNumber::new();
+        latest_verion.parse_from_string(&get_latest_version());
+
+        if current_version.is_major_update(&latest_verion) {
+            log!(" ");
+            log!("Warning, Latest Version has major release. Please consider reading documentation after update");
+            log!(" ");
+            log!("To get more information please visit: https://github.com/cophilot/templify/blob/master/CHANGELOG.md");
+            log!(" ");
+        }
+
         log!("Updating templify...");
     }
 

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -28,8 +28,6 @@ pub(crate) fn update(command: &Command) -> Status {
     if !utils::functions::check_internet_connection() {
         return Status::error("You need a internet connection to update templify.".to_string());
     }
-    let mut current_version = VersionNumber::new();
-    current_version.parse_from_string(env!("CARGO_PKG_VERSION"));
 
     let version = command.get_value_flag("version").clone();
 
@@ -37,6 +35,9 @@ pub(crate) fn update(command: &Command) -> Status {
         log!("templify is already up to date.");
         return Status::ok();
     }
+
+    let mut current_version = VersionNumber::new();
+    current_version.parse_from_string(env!("CARGO_PKG_VERSION"));
 
     if !version.is_empty() {
         let mut version_number = VersionNumber::new();

--- a/src/types/version_number.rs
+++ b/src/types/version_number.rs
@@ -66,4 +66,11 @@ impl VersionNumber {
         }
         false
     }
+
+    pub fn is_major_update(&self, other: &VersionNumber) -> bool {
+        if self.major != other.major {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/types/version_number.rs
+++ b/src/types/version_number.rs
@@ -67,6 +67,7 @@ impl VersionNumber {
         false
     }
 
+    /// Check if this version number has major version difference than the other
     pub fn is_major_update(&self, other: &VersionNumber) -> bool {
         if self.major != other.major {
             return true;


### PR DESCRIPTION
Replace the `...` with your own content!

## Type of change

_Please select the relevant option:_

-   [x] Bug fix
-   [x] New feature
-   [ ] New test
-   [ ] Refactoring / code cleanup
-   [ ] Documentation
-   [ ] Other (please describe here: ...)

## Description

_Please provide a brief description of the changes made in this pull request:_

On updating (upgrading/downgrading) templify version , a warning will be displayed to let the user know, that this updation has major release which might have breaking changes. Consider reading documentation, with link to CHANGELOG.md, so that user will easily navigate and see the changing for the updating version.

## Changes

_Please add a list of changes made in this pull request:_

-   First of all , implemented a function in the `VersionNumber` type to check if a two versions are differed by a major version. This function will be called on `self`(`VersionNumber`), and will take another reference of `VersionNumber` to compare.
-   In the execution function of `update` command, in the scenerio where version number is provided, I am checking if the current version number is different in major version from the provided version. If they do so , I am logging some message.
- In other scenerio, when the version number is not provided, and its updating to the latest stable version , I am checking that if the current version and the latest version is differed by the major relase, if they do so I am loggging certain messages.

## Demo

1. Case when updating to latest version

https://github.com/user-attachments/assets/c0947ffb-b52c-428b-8356-cf85622bfc57


2. Manual Changing Major Version

[Manual Version Update.webm](https://github.com/user-attachments/assets/83ea3456-4ba0-404e-8668-79181566ad48)




