### PR TITLE
Fix : Generate No Files or All Files

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -210,9 +210,8 @@ pub(crate) fn generate(command: &Command) -> Status {
                 std::fs::create_dir_all(&file.path).unwrap();
             } else {
                 let mut new_file = std::fs::File::create(&file.path).unwrap();
-                match file.file_content {
-                    Some(val) => new_file.write_all(val.as_bytes()).unwrap(),
-                    None => {}
+                if let Some(val) = file.file_content {
+                    new_file.write_all(val.as_bytes()).unwrap();
                 }
 
                 let abs_path = std::fs::canonicalize(&file.path).unwrap();
@@ -221,7 +220,7 @@ pub(crate) fn generate(command: &Command) -> Status {
             }
         }
 
-        if !dry_run {
+        if dry_run {
             log!("Files would be generated successfully.");
             return Status::ok();
         }

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -2,7 +2,6 @@ use crate::log;
 use crate::types::argument::Argument;
 use crate::types::command::Command;
 use crate::types::flag::Flag;
-use crate::types::generate_types::FileToCreate;
 use crate::types::status::Status;
 use crate::{types, utils};
 use std::io::Write;
@@ -186,32 +185,14 @@ pub(crate) fn generate(command: &Command) -> Status {
         std::fs::create_dir_all(&new_path).unwrap();
     }
 
-    let mut files_to_create: Vec<FileToCreate> = Vec::new();
-
-    if utils::template_handler::generate_template_dir(
+    if utils::template_handler::generate_template(
         &format!(".templates/{}", template_name),
         &new_path,
         given_name.as_str(),
         dry_run,
         meta.clone(),
         force,
-        &mut files_to_create,
     ) {
-        for file in files_to_create {
-            if file.is_dir {
-                std::fs::create_dir_all(&file.path).unwrap();
-            } else {
-                let mut new_file = std::fs::File::create(&file.path).unwrap();
-                if let Some(val) = file.file_content {
-                    new_file.write_all(val.as_bytes()).unwrap();
-                }
-
-                let abs_path = std::fs::canonicalize(&file.path).unwrap();
-
-                log!("Created file {}", abs_path.to_str().unwrap());
-            }
-        }
-
         if dry_run {
             log!("Files would be generated successfully.");
             return Status::ok();

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -198,10 +198,6 @@ pub(crate) fn generate(command: &Command) -> Status {
         &mut files_to_create,
     ) {
         for file in files_to_create {
-            if dry_run {
-                log!("Would create file {}", file.path);
-                continue;
-            }
             if file.is_dir {
                 std::fs::create_dir_all(&file.path).unwrap();
             } else {

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -5,11 +5,12 @@ use crate::types::flag::Flag;
 use crate::types::status::Status;
 use crate::{types, utils};
 use std::io::Write;
+use std::path::Path;
 
 pub struct FileToCreate {
     pub path: String,
     pub is_dir: bool,
-    pub file_content: String,
+    pub file_content: Option<String>,
 }
 
 /// The definition of the generate command.
@@ -208,23 +209,18 @@ pub(crate) fn generate(command: &Command) -> Status {
             if file.is_dir {
                 std::fs::create_dir_all(&file.path).unwrap();
             } else {
-                if Path::new(&file.path).exists() {
-                    if force {
-                        if !dry_run {
-                            std::fs::remove_file(&file.path).unwrap();
-                        }
-                    } else {
-                        log!("File {} already exists.", new_path);
-                    }
-                }
                 let mut new_file = std::fs::File::create(&file.path).unwrap();
-                new_file.write_all(file.file_content.as_bytes()).unwrap();
+                match file.file_content {
+                    Some(val) => new_file.write_all(val.as_bytes()).unwrap(),
+                    None => {}
+                }
+
                 let abs_path = std::fs::canonicalize(&file.path).unwrap();
-                
+
                 log!("Created file {}", abs_path.to_str().unwrap());
             }
         }
-        
+
         if !dry_run {
             log!("Files would be generated successfully.");
             return Status::ok();

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -2,16 +2,10 @@ use crate::log;
 use crate::types::argument::Argument;
 use crate::types::command::Command;
 use crate::types::flag::Flag;
+use crate::types::generate_types::FileToCreate;
 use crate::types::status::Status;
 use crate::{types, utils};
 use std::io::Write;
-use std::path::Path;
-
-pub struct FileToCreate {
-    pub path: String,
-    pub is_dir: bool,
-    pub file_content: Option<String>,
-}
 
 /// The definition of the generate command.
 pub(crate) fn definition() -> Command {

--- a/src/types/generate_types.rs
+++ b/src/types/generate_types.rs
@@ -1,0 +1,6 @@
+/// The Definition of Files to be created
+pub(crate) struct FileToCreate {
+    pub path: String,
+    pub is_dir: bool,
+    pub file_content: Option<String>,
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,6 +1,7 @@
 pub mod argument;
 pub mod command;
 pub mod flag;
+pub mod generate_types;
 pub mod global_flag;
 pub mod load_types;
 pub mod placeholder_definition;

--- a/src/utils/template_handler.rs
+++ b/src/utils/template_handler.rs
@@ -527,7 +527,7 @@ fn load_remote_gitlab_template_file(path: &str, url: &str, force: bool) -> Statu
     log!("Created file {}", path);
     Status::ok()
 }
-/// Generate a template directory from a template
+/// Generate a template files and directory from a template
 pub(crate) fn generate_template(
     path: &str,
     new_path: &str,

--- a/src/utils/template_handler.rs
+++ b/src/utils/template_handler.rs
@@ -565,7 +565,6 @@ pub(crate) fn generate_template_dir(
                     is_dir: true,
                     path: new_path.clone(),
                 });
-                // std::fs::create_dir_all(&new_path).unwrap();
             }
             if !generate_template_dir(
                 path.to_str().unwrap(),

--- a/src/utils/template_handler.rs
+++ b/src/utils/template_handler.rs
@@ -1,6 +1,6 @@
 use super::rest;
-use crate::commands::generate::FileToCreate;
 use crate::log;
+use crate::types::generate_types::FileToCreate;
 use crate::types::load_types::URLType;
 use crate::types::status::Status;
 use crate::types::template_meta::TemplateMeta;

--- a/src/utils/template_handler.rs
+++ b/src/utils/template_handler.rs
@@ -561,7 +561,7 @@ pub(crate) fn generate_template_dir(
         if path.is_dir() {
             if !dry_run {
                 files_to_create.push(FileToCreate {
-                    file_content: "".to_string(),
+                    file_content: None,
                     is_dir: true,
                     path: new_path.clone(),
                 });
@@ -606,16 +606,16 @@ pub(crate) fn generate_template_file(
     let file_content = std::fs::read_to_string(path).unwrap();
     let file_content = formater::handle_placeholders(&file_content, given_name, meta);
 
-    // if Path::new(new_path).exists() {
-    //     if force {
-    //         if !dry_run {
-    //             std::fs::remove_file(new_path).unwrap();
-    //         }
-    //     } else {
-    //         log!("File {} already exists.", new_path);
-    //         return false;
-    //     }
-    // }
+    if Path::new(new_path).exists() {
+        if force {
+            if !dry_run {
+                std::fs::remove_file(new_path).unwrap();
+            }
+        } else {
+            log!("File {} already exists.", new_path);
+            return false;
+        }
+    }
 
     if dry_run {
         log!("Would create file {}", new_path);
@@ -623,16 +623,11 @@ pub(crate) fn generate_template_file(
     }
 
     files_to_create.push(FileToCreate {
-        file_content,
-        is_dir: true,
+        file_content: Some(file_content),
+        is_dir: false,
         path: new_path.to_string(),
     });
-    // let mut new_file = std::fs::File::create(new_path).unwrap();
-    // new_file.write_all(file_content.as_bytes()).unwrap();
-    //
-    // let abs_path = std::fs::canonicalize(new_path).unwrap();
-    //
-    // log!("Created file {}", abs_path.to_str().unwrap());
+    
     true
 }
 

--- a/tests/command_tests/generate_test.rs
+++ b/tests/command_tests/generate_test.rs
@@ -219,6 +219,22 @@ pub fn test() {
         .check_not_exists();
     utils::run_successfully("tpy generate MyTest test -reload");
     fs::dir("src").file("file.txt").check_all_exists();
+
+    fs::templates_dir().dir("MyTest").file("file.txt").remove();
+    fs::templates_dir()
+        .dir("MyTest")
+        .file(".templify.yml")
+        .create();
+    fs::templates_dir().dir("MyTest").file("test.txt").create();
+    fs::templates_dir()
+        .dir("MyTest")
+        .file("$$name$$.txt")
+        .create();
+
+    utils::run_successfully("tpy generate MyTest test1");
+    utils::run_failure("tpy generate MyTest test2");
+    log::contains_line("File ./test.txt already exists.");
+    fs::file("test2.txt").check_not_exists();
 }
 
 fn check_case_conversion_generated_file(file: &mut FSItem) {


### PR DESCRIPTION
Replace the `...` with your own content!

## Type of change


-   [x] Bug fix
-   [ ] New feature
-   [ ] New test
-   [ ] Refactoring / code cleanup
-   [ ] Documentation
-   [ ] Other (please describe here: ...)

## Description

Previously, an issue occurred when generating files from a template. If the generation process failed for any reason, users were left with an inconsistent state, where some files were generated while others were not. I have resolved this issue by implementing a tracking system that monitors all created files during the generation process. If the process fails midway, all generated files will be removed, ensuring the state remains consistent and as it was before the process started, thereby preventing any inconsistency.

## Changes

I created a vector of tuples that contain information about the path of each file or directory created, as well as a flag indicating whether it is a directory. If the generation process fails, the system will iterate through the created paths, check their existence, and remove them based on whether they are directories or files. This ensures that the state remains consistent and free from partial generation artifacts.

-   ...
-   ...
- Image after failed execution of generate command
![image](https://github.com/user-attachments/assets/fb3710ac-3101-498b-b581-bed6a3fbea8a)

